### PR TITLE
Fix: runTask() with custom name

### DIFF
--- a/android/src/main/java/com/supersami/foregroundservice/ForegroundServiceTask.java
+++ b/android/src/main/java/com/supersami/foregroundservice/ForegroundServiceTask.java
@@ -24,7 +24,7 @@ public class ForegroundServiceTask extends HeadlessJsTaskService {
         Bundle extras = intent.getExtras();
         if (extras != null) {
             return new HeadlessJsTaskConfig(
-                    "myTaskName",
+                    extras.getString("taskName"),
                     Arguments.fromBundle(extras),
                     5000, // timeout for the task
                     true // optional: defines whether or not  the task is allowed in foreground. Default is false


### PR DESCRIPTION
Hi ! I love your work on this service 👍 I'm a beginner in react-native and I have little to no experience in Java / Android programming

I think I found a problem in the function `ForegroundService.runTask()`. We can't define a custom taskName, it will always try to run the task registered with the "myTaskName" name.

However, we can define a custom name when we register the task with `ForegroundService.registerForegroundTask()`;

```
await ForegroundService.runTask({
        taskName: "customName",
        delay: 0,
        loopDelay: 5000,
        onLoop: false,
});
```
This code will try to run the task registered as "myTaskName"

I think it works well with this fix